### PR TITLE
Remove flag from x86, add lexecinfo build command

### DIFF
--- a/games-strategy/openxcom/openxcom-1.0_20180514.recipe
+++ b/games-strategy/openxcom/openxcom-1.0_20180514.recipe
@@ -19,7 +19,7 @@ SOURCE_DIR="OpenXcom-$srcGitRev"
 PATCHES="openxcom-$portVersion.patchset"
 ADDITIONAL_FILES="openxcom.rdef"
 
-ARCHITECTURES="!x86_gcc2 ?x86_64 ?x86"
+ARCHITECTURES="!x86_gcc2 ?x86_64 x86"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -65,6 +65,7 @@ defineDebugInfoPackage openxcom$secondaryArchSuffix \
 
 BUILD()
 {
+	export LDFLAGS="-lexecinfo"
 	cmake . \
 		$cmakeDirArgs
 


### PR DESCRIPTION
Allow package to be built on x86 architecture, added necessary command to build section.